### PR TITLE
When viewing item from link, sometimes its folder is kept readonly

### DIFF
--- a/public/js/items.js
+++ b/public/js/items.js
@@ -363,8 +363,10 @@ async function itemViewFill (item, gotofolder) {
   jhQuery('#viewpassword').setAttribute('type', 'password')
 
   if (gotofolder) {
-    PW.treeItemSelect(`item-${body.data.folderid}`)
-    await fillItems()
+    jhQuery('#folderstree').updateComplete.then(async () => {
+      PW.treeItemSelect(`item-${body.data.folderid}`)
+      await fillItems()
+    })
   }
 }
 


### PR DESCRIPTION
Ensure tree is completely updated before selecting the folder and loading its items.

Fixes #91