### PR TITLE
Rework JS imports, browser side imports already perform HTTP GET

### DIFF
--- a/passweaver-gui.mjs
+++ b/passweaver-gui.mjs
@@ -142,7 +142,7 @@ app.use(
 )
 
 // Public static
-app.use('/public', Express.static('./public', { maxAge: cfg.static_maxage_sec * 1000 }))
+app.use('/public/v1.0.2', Express.static('./public', { maxAge: cfg.static_maxage_sec * 1000 }))
 
 // Log errors
 const logErrors = RFS.createStream(`${cfg.log.dir}/passweaver-gui-errors.log`, {

--- a/views/folders.ejs
+++ b/views/folders.ejs
@@ -65,9 +65,6 @@
 <%- include("partials/grouppicker.ejs") %>
 </div>
 
-<script defer type="module" src="/public/js/folders_shared.js?v<%= version %>"></script>
-<script defer type="module" src="/public/js/folders.js?v<%= version %>"></script>
-<script defer type="module" src="/public/js/grouppicker.js?v<%= version %>" type="text/javascript"></script>
-<script defer type="module" src="/public/js/userpicker.js?v<%= version %>" type="text/javascript"></script>
+<script defer type="module" src="/public/v<%= version %>/js/folders.js"></script>
 
 <%- include('partials/footer.ejs') %>

--- a/views/generate.ejs
+++ b/views/generate.ejs
@@ -17,7 +17,7 @@
   </div>
 </div>
 
-<script defer type="module" src="/public/js/generate.js?v<%= version %>"></script>
+<script defer type="module" src="/public/v<%= version %>/js/generate.js"></script>
 
 <%- include('partials/commondialogs.ejs') %>
 <%- include('partials/footer.ejs') %>

--- a/views/groups.ejs
+++ b/views/groups.ejs
@@ -65,6 +65,6 @@
 
 </div>
 
-<script defer type="module" src="/public/js/groups.js?v<%= version %>"></script>
+<script defer type="module" src="/public/v<%= version %>/js/groups.js"></script>
 
 <%- include('partials/footer.ejs') %>

--- a/views/items.ejs
+++ b/views/items.ejs
@@ -79,8 +79,7 @@
 
 </div>
 
-<script defer type="module" src="/public/js/folders_shared.js?v<%= version %>"></script>
-<script defer type="module" src="/public/js/items.js?v<%= version %>"></script>
+<script defer type="module" src="/public/v<%= version %>/js/items.js"></script>
 
 <%- include('partials/footer.ejs') %>
 

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -4,7 +4,7 @@
   <div class="login-content">
     <div class="pill bordered" style="padding:2rem;">
       <center>
-        <img src="/public/images/passweaver-icon-dark.png" width="60"></img>
+        <img src="/public/v<%= version %>/images/passweaver-icon-dark.png" width="60"></img>
         <p style="font-size:200%;">PassWeaver - <%- company_name %></p>
       </center>
       <form id="loginForm" action="access" method="post">
@@ -28,6 +28,6 @@
   </div>
 </div>
 
-<script defer type="module" src="/public/js/login.js?v<%= version %>"></script>
+<script defer type="module" src="/public/v<%= version %>/js/login.js"></script>
 
 <%- include('partials/footer.ejs') %>

--- a/views/onetimesecret.ejs
+++ b/views/onetimesecret.ejs
@@ -27,7 +27,7 @@
 
 </div>
 
-<script defer type="module" src="/public/js/onetimesecret.js?v<%= version %>"></script>
+<script defer type="module" src="/public/v<%= version %>/js/onetimesecret.js"></script>
 
 <%- include('partials/commondialogs.ejs') %>
 

--- a/views/onetimesecretshow.ejs
+++ b/views/onetimesecretshow.ejs
@@ -27,7 +27,7 @@
 
 </div>
 
-<script defer type="module" src="/public/js/onetimesecretshow.js?v<%= version %>"></script>
+<script defer type="module" src="/public/v<%= version %>/js/onetimesecretshow.js"></script>
 
 <%- include('partials/commondialogs.ejs') %>
 

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -4,10 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.18.0/cdn/themes/<%- theme %>.css"/>
-  <link href="/public/css/passweaver.css?v<%= version %>" rel="stylesheet">
+  <link href="/public/v<%= version%>/css/passweaver.css" rel="stylesheet">
 </head>
 <body>
   <script type="module" src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.18.0/cdn/shoelace-autoloader.js" crossorigin="anonymous"></script>
-  <script src="/public/js/jh.js?v<%= version %>" type="text/javascript"></script>
-  <script type="module" src="/public/js/passweaver-gui.js?v<%= version %>"></script>
+  <script src="/public/v<%= version%>/js/jh.js" type="text/javascript"></script>
   <input type="hidden" id="v-user" value="<%= user %>" />

--- a/views/partials/sidebar-anon.ejs
+++ b/views/partials/sidebar-anon.ejs
@@ -1,6 +1,6 @@
 <div class="page-sidebar">
   <div class="logo">
-    <img src="/public/images/passweaver-icon-light.png" width="36px"></img>
+    <img src="/public/v<%= version %>/images/passweaver-icon-light.png" width="36px"></img>
   </div>
 
   <input type="hidden" id="pageid" value="<%- pageid %>"></input>

--- a/views/partials/sidebar.ejs
+++ b/views/partials/sidebar.ejs
@@ -1,6 +1,6 @@
 <div class="page-sidebar">
   <div class="logo" title="PassWeaver">
-    <img src="/public/images/passweaver-icon-light.png" width="36px"></img>
+    <img src="/public/v<%= version %>/images/passweaver-icon-light.png" width="36px"></img>
   </div>
 
   <input type="hidden" id="pageid" value="<%- pageid %>"></input>

--- a/views/preferences.ejs
+++ b/views/preferences.ejs
@@ -88,7 +88,7 @@
 
 </div>
 
-<script defer type="module" src="/public/js/preferences.js?v<%= version %>"></script>
+<script defer type="module" src="/public/v<%= version %>/js/preferences.js"></script>
 
 <%- include('partials/commondialogs.ejs') %>
 

--- a/views/search.ejs
+++ b/views/search.ejs
@@ -32,6 +32,6 @@
 <%- include('partials/commondialogs.ejs') %>
 <%- include('partials/itemview.ejs') %>
 
-<script defer type="module" src="/public/js/search.js?v<%= version %>"></script>
+<script defer type="module" src="/public/v<%= version %>/js/search.js"></script>
 
 <%- include('partials/footer.ejs') %>

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -47,6 +47,6 @@
 
 </div>
 
-<script defer type="module" src="/public/js/settings.js?v<%= version %>"></script>
+<script defer type="module" src="/public/v<%= version %>/js/settings.js"></script>
 
 <%- include('partials/footer.ejs') %>

--- a/views/users.ejs
+++ b/views/users.ejs
@@ -79,8 +79,6 @@
 
 </div>
 
-<script defer type="module" src="/public/js/users.js?v<%= version %>"></script>
-<script defer type="module" src="/public/js/grouppicker.js?v<%= version %>" type="text/javascript"></script>
-<script defer type="module" src="/public/js/userpicker.js?v<%= version %>" type="text/javascript"></script>
+<script defer type="module" src="/public/v<%= version %>/js/users.js"></script>
 
 <%- include('partials/footer.ejs') %>


### PR DESCRIPTION
Server static resources in a versioned path, in order to guarantee browser cache to work correctly.

Remove duplicate imports in EJS files, they're already loaded by browser imports.

Fixes #108