### PR TITLE
When creating a secret from generator, the "Create link" button is disabled

### DIFF
--- a/public/js/onetimesecret.js
+++ b/public/js/onetimesecret.js
@@ -59,3 +59,5 @@ JH.event('#save', 'click', async (ev) => {
   JH.query('#result').style.visibility = 'visible'
   PW.showToast('success', 'Link created')
 })
+
+enableSave()


### PR DESCRIPTION
Fixes #208