### PR TITLE
When creating a one time secret from generator page, create link button is disabled

### DIFF
--- a/public/js/onetimesecret.js
+++ b/public/js/onetimesecret.js
@@ -72,7 +72,7 @@ JH.event(domCache.saveButton, 'click', async (ev) => {
   PW.showToast('success', 'Link created')
 })
 
-enableSave()
+setTimeout(enableSave, 100)
 
 // Picker
 const UPicker = new CPicker.Picker('users', userChoosen)


### PR DESCRIPTION
Fixes #317